### PR TITLE
Update estadosPagoSincopro.cs

### DIFF
--- a/Lai.Fwk.Enum/estadosPagoSincopro.cs
+++ b/Lai.Fwk.Enum/estadosPagoSincopro.cs
@@ -1,9 +1,9 @@
 ﻿namespace Lai.Fwk.Enumeradores
 {
     /// <summary>
-    /// 
+    /// Enumerador General de Estados de Pago, Cambio en nomenclatura a CamelCase
     /// </summary>
-    public enum estadosPagoSincopro
+    public enum EstadosPagoSinCopro
     {
         Pagado = 80,
         Pendiente = 81,


### PR DESCRIPTION
Cambio en el nombre del enumerador para adoptar CamelCase en lugar de PascalCase.
Resultado "EstadosPagoSinCopro"